### PR TITLE
Adicionando material de Halide e APSH

### DIFF
--- a/_includes/modal.html
+++ b/_includes/modal.html
@@ -65,7 +65,8 @@
 				<p>Além disso, o curso cobre uma ampla gama de tópicos que vão desde a introdução a conceitos básicos e estruturas de Halide, até técnicas avançadas de scheduling e metaprogramação. Você terá a chance de trabalhar com buffers, variáveis, expressões e domínios de redução, além de explorar métodos de depuração e benchmarking. Aplicações práticas incluem filtragem, realce de imagens, operações em espaços de cor e criação de efeitos visuais. Este curso é ideal para quem deseja transformar sua paixão em habilidades técnicas de ponta no campo da computação gráfica.</p>
 				<br>
 				<h3>Material do Curso</h3>
-				<a>Previsão de liberação do material no dia 29/07/2024</a>
+				<h3><a href="https://www.youtube.com/playlist?list=PL7Od71iXIaNkmm_P-SvnzbKd0n4sYXmGQ" class="align-middle"><i class="material-icons align-middle">video_library</i> Aulas em vídeo</a></h3><br>
+				<h3><a href="https://drive.google.com/drive/folders/1Ei6tEYGPF6Qit4MQ40k2SsxHJfJPOAwA" class="align-middle"><i class="material-icons align-middle">menu_book</i> Material Prático</a></h3>
 			</div>
 			<div class="modal-footer">
 				<button type="button" class="btn btn-secondary" data-dismiss="modal">Fechar</button>
@@ -90,8 +91,9 @@
 				<p>Ao participar deste curso, você terá acesso a tópicos abrangentes, desde a classificação das arquiteturas de processamento até a programação em CUDA e OpenCL. Através de exemplos práticos, como operações básicas em imagens e algoritmos de paralelismo, você desenvolverá habilidades essenciais para otimizar a performance e o consumo de energia dos sistemas. Além disso, você irá implementar tarefas desafiadoras e comparar a performance em diferentes modelos, preparando-se para enfrentar problemas reais e complexos no campo da computação. Venha se tornar um especialista em sistemas heterogêneos e impulsione sua carreira com conhecimentos de ponta!</p>
 				<br>
 				<h3>Material do Curso</h3>
-				<a>Previsão de liberação do material no dia 12/08/2024</a>
-			</div>
+				<h3><a href="https://www.youtube.com/playlist?list=PL7Od71iXIaNmvz2Wp2_cEP71JnmzypQ4V" class="align-middle"><i class="material-icons align-middle">video_library</i> Aulas em vídeo</a></h3><br>
+				<h3><a href="https://drive.google.com/drive/folders/1rwQzZ7hWBHo5zJwfdCe7LeI0eHbc4oy0" class="align-middle"><i class="material-icons align-middle">menu_book</i> Material Teórico</a></h3>
+				<h3><a href="https://github.com/TIC-13/luxai_cuda_samples" class="align-middle"><i class="material-icons align-middle">code</i> Github com exercícios e exemplos</a></h3>			</div>
 			<div class="modal-footer">
 				<button type="button" class="btn btn-secondary" data-dismiss="modal">Fechar</button>
 			</div>

--- a/cursos.html
+++ b/cursos.html
@@ -122,6 +122,18 @@
 			} else if (window.location.href.indexOf("#ModalDeep") > -1) {
 				var mobileModal = new bootstrap.Modal(document.getElementById('ModalDeep'));
 				mobileModal.show();
+			} else if (window.location.href.indexOf("#ModalHalide") > -1) {
+				var mobileModal = new bootstrap.Modal(document.getElementById('ModalHalide'));
+				mobileModal.show();
+			} else if (window.location.href.indexOf("#ModalAPSH") > -1) {
+				var mobileModal = new bootstrap.Modal(document.getElementById('ModalAPSH'));
+				mobileModal.show();
+			} else if (window.location.href.indexOf("#ModalAPHIA") > -1) {
+				var mobileModal = new bootstrap.Modal(document.getElementById('ModalAPHIA'));
+				mobileModal.show();
+			} else if (window.location.href.indexOf("#ModalIQA") > -1) {
+				var mobileModal = new bootstrap.Modal(document.getElementById('ModalIQA'));
+				mobileModal.show();
 			}
 		});
 	</script>


### PR DESCRIPTION
Foi adicionado o material de Halide (playlist e material teórico/prático) e do curso de Análise e Performance de Sistemas Heterogeneos (playlist, material teórico e repositório)

O script js que lê o nome do modal na url e abre automaticamente foi atualizado para todos os cursos