### PR TITLE
Add Docker support for local development

### DIFF
--- a/run_locally/Docker.md
+++ b/run_locally/Docker.md
@@ -1,0 +1,17 @@
+
+#### To start the Docker server, first build the image, then launch the server:
+
+```bash
+docker build -f run_locally/Dockerfile -t site . && \
+docker run --rm -p 4000:4000 --network="host" site
+```
+
+Always execute `docker build` before running the `docker run` command to ensure the website content is updated. **If you need to use this container for development**, please consider creating a container with the command below. Update the volume path to sync the project code inside the container (you may encounter some warnings about permissions).
+
+```bash
+docker run -it -v $(pwd):/app -w /app -p 4000:4000 --network="host" --rm --entrypoint /bin/bash ruby:latest
+```
+
+After initiating the development container, you can install dependencies (as described in the [Dockerfile](./Dockerfile)) and run the bundler and server.
+
+> The container will be removed after you detach. If you wish to detach without removing the container, omit the `--rm` option from the `docker run` command.

--- a/run_locally/Dockerfile
+++ b/run_locally/Dockerfile
@@ -1,0 +1,24 @@
+FROM ruby:latest
+
+# Fuso horário
+ENV TZ=America/Recife
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Localidades
+RUN apt-get update && apt-get install -y locales locales-all
+RUN locale-gen pt_BR.UTF-8
+ENV LC_ALL=pt_BR.UTF-8 LANG=pt_BR.UTF-8 LANGUAGE=pt_BR.UTF-8
+
+WORKDIR /app
+COPY . /app
+RUN cp ./run_locally/default_config.yml ./_config.yml
+
+RUN gem install jekyll bundler
+
+RUN bundle install
+
+# This port is defined on yml config file
+EXPOSE 4000
+
+# Start server using yml config file
+CMD ["/bin/bash", "-c", "bundle exec jekyll serve"]


### PR DESCRIPTION
### Main goals:
- Add a Dockerfile to build and run the test server
- Include instructions for using the Dockerfile and options to utilize container for development