### PR TITLE
Major overhaul on navigation menu + changes in local testing, removing old junk and fixing links

### DIFF
--- a/LLMs.html
+++ b/LLMs.html
@@ -32,7 +32,6 @@
 	<link href="https://fonts.googleapis.com/css?family=Poppins:400,700|Righteous&display=swap" rel="stylesheet">
 	<!-- owl stylesheets -->
 	<link rel="stylesheet" href="css/owl.carousel.min.css">
-	<link rel="stylesheet" href="css/owl.theme.default.min.css">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css"
 		media="screen">
 </head>
@@ -114,7 +113,6 @@
 	<script src="js/jquery.mCustomScrollbar.concat.min.js"></script>
 	<script src="js/custom.js"></script>
 	<!-- javascript -->
-	<script src="js/owl.carousel.js"></script>
 	<script src="https:cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 </body>
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,8 @@
 	<div class="container">
 		<div class="location_main">
 			<h1>Contato</h1>
-			<h2><a href="mailto:luxai@softex.cin.ufpe.br"><i class="material-icons align-middle">mail</i>
+			<h2><a href="mailto:luxai@softex.cin.ufpe.br" target="_blank" rel="noopener noreferrer"><i
+						class="material-icons align-middle">mail</i>
 					luxai@softex.cin.ufpe.br</a></h2>
 		</div>
 		<!--div class="social_icon">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 <div class="header_main">
    <div class="mobile_menu">
-      <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <nav class="navbar navbar-expand-md navbar-light bg-light">
          <div class="logo_mobile"><a href="index.html"><img src="images/logo.png" style="max-width: 128px"></a></div>
          <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
             aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
@@ -36,33 +36,29 @@
       </nav>
    </div>
    <div class="menu_main">
-      <nav class="navbar navbar-expand-md navbar-light bg-light">
-         <div class="logo" style="max-width: 128px"><a href="index.html"><img src="images/logo.png"></a></div>
-         <div class="collapse navbar-collapse justify-content-center" id="navbarNav">
-            <ul class="navbar-nav">
-               <li class="nav-item">
-                  <a class="nav-link" href="index.html">Home</a>
-               </li>
-               <li class="nav-item">
-                  <a class="nav-link" href="sobre.html">Sobre</a>
-               </li>
-               <li class="nav-item dropdown">
-                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown"
-                     aria-haspopup="true" aria-expanded="false">
-                     Soluções
-                  </a>
-                  <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                     <a class="nav-link dropdown-item" href="cursos.html">Cursos</a>
-                     <a class="nav-link dropdown-item" href="benchmarks.html">Benchmarks</a>
-                     <a class="nav-link dropdown-item" href="LLMs.html">LLMs</a>
-                     <!--a class="nav-link dropdown-item" href="apps.html">Apps</a-->
-                  </div>
-               </li>
-               <li class="nav-item">
-                  <a class="nav-link " href="publicacoes.html">Publicações</a>
-               </li>
-            </ul>
-         </div>
-      </nav>
+      <ul class="nav navbar-expand-md navbar-light bg-light">
+         <li><div class="logo align-self-center"><a href="index.html"><img src="images/logo.png"></a></div></li>
+         <li class="nav-item align-self-center">
+            <a class="nav-link" href="index.html">Home</a>
+         </li>
+         <li class="nav-item align-self-center">
+            <a class="nav-link" href="sobre.html">Sobre</a>
+         </li>
+         <li class="nav-item dropdown align-self-center">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown"
+               aria-haspopup="true" aria-expanded="false">
+               Soluções
+            </a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+               <a class="nav-link dropdown-item" href="cursos.html">Cursos</a>
+               <a class="nav-link dropdown-item" href="benchmarks.html">Benchmarks</a>
+               <a class="nav-link dropdown-item" href="LLMs.html">LLMs</a>
+               <!--a class="nav-link dropdown-item" href="apps.html">Apps</a-->
+            </div>
+         </li>
+         <li class="nav-item align-self-center">
+            <a class="nav-link " href="publicacoes.html">Publicações</a>
+         </li>
+      </ul>
    </div>
 </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,17 +16,17 @@
                <li class="nav-item">
                   <a class="nav-link" href="sobre.html">Sobre</a>
                </li>
-               <li class="nav-item">
-                  <a class="nav-link" href="cursos.html">Cursos</a>
-               </li>
-               <!--li class="nav-item">
-                        <a class="nav-link " href="apps.html">Apps</a>
-                     </li-->
-               <li class="nav-item">
-                  <a class="nav-link " href="benchmarks.html">Benchmarks</a>
-               </li>
-               <li class="nav-item">
-                  <a class="nav-link " href="LLMs.html">LLMs</a>
+               <li class="nav-item dropdown">
+                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown"
+                     aria-haspopup="true" aria-expanded="false">
+                     Soluções
+                  </a>
+                  <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                     <a class="nav-link dropdown-item" href="cursos.html">Cursos</a>
+                     <a class="nav-link dropdown-item" href="benchmarks.html">Benchmarks</a>
+                     <a class="nav-link dropdown-item" href="LLMs.html">LLMs</a>
+                     <!--a class="nav-link dropdown-item" href="apps.html">Apps</a-->
+                  </div>
                </li>
                <li class="nav-item">
                   <a class="nav-link " href="publicacoes.html">Publicações</a>
@@ -35,19 +35,34 @@
          </div>
       </nav>
    </div>
-   <div class="container-fluid">
-      <div class="menu_main">
-         <ul>
-            <li class="d-flex align-items-center"><a href="index.html"><img src="images/logo.png"
-                     style="max-width: 128px"></a></li>
-            <li class="active d-flex align-items-center"><a href="index.html">Home</a></li>
-            <li class="d-flex align-items-center"><a href="sobre.html">Sobre</a></li>
-            <li class="d-flex align-items-center"><a href="cursos.html">Cursos</a></li>
-            <!--li class="d-flex align-items-center"><a href="apps.html">Apps</a></li-->
-            <li class="d-flex align-items-center"><a href="benchmarks.html">Benchmarks</a></li>
-            <li class="d-flex align-items-center"><a href="LLMs.html">LLMs</a></li>
-            <li class="d-flex align-items-center"><a href="publicacoes.html">Publicações</a></li>
-         </ul>
-      </div>
+   <div class="menu_main">
+      <nav class="navbar navbar-expand-md navbar-light bg-light">
+         <div class="logo" style="max-width: 128px"><a href="index.html"><img src="images/logo.png"></a></div>
+         <div class="collapse navbar-collapse justify-content-center" id="navbarNav">
+            <ul class="navbar-nav">
+               <li class="nav-item">
+                  <a class="nav-link" href="index.html">Home</a>
+               </li>
+               <li class="nav-item">
+                  <a class="nav-link" href="sobre.html">Sobre</a>
+               </li>
+               <li class="nav-item dropdown">
+                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown"
+                     aria-haspopup="true" aria-expanded="false">
+                     Soluções
+                  </a>
+                  <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                     <a class="nav-link dropdown-item" href="cursos.html">Cursos</a>
+                     <a class="nav-link dropdown-item" href="benchmarks.html">Benchmarks</a>
+                     <a class="nav-link dropdown-item" href="LLMs.html">LLMs</a>
+                     <!--a class="nav-link dropdown-item" href="apps.html">Apps</a-->
+                  </div>
+               </li>
+               <li class="nav-item">
+                  <a class="nav-link " href="publicacoes.html">Publicações</a>
+               </li>
+            </ul>
+         </div>
+      </nav>
    </div>
 </div>

--- a/_includes/modal.html
+++ b/_includes/modal.html
@@ -106,11 +106,13 @@
 					paixão em habilidades técnicas de ponta no campo da computação gráfica.</p>
 				<br>
 				<h3>Material do Curso</h3>
-				<h3><a href="https://www.youtube.com/playlist?list=PL7Od71iXIaNkmm_P-SvnzbKd0n4sYXmGQ"
-						class="align-middle"><i class="material-icons align-middle">video_library</i> Aulas em vídeo</a>
+				<h3><a href="https://www.youtube.com/playlist?list=PL7Od71iXIaNkmm_P-SvnzbKd0n4sYXmGQ" target="_blank"
+						rel="noopener noreferrer" class="align-middle"><i
+							class="material-icons align-middle">video_library</i> Aulas em vídeo</a>
 				</h3><br>
-				<h3><a href="https://drive.google.com/drive/folders/1Ei6tEYGPF6Qit4MQ40k2SsxHJfJPOAwA"
-						class="align-middle"><i class="material-icons align-middle">menu_book</i> Material Prático</a>
+				<h3><a href="https://drive.google.com/drive/folders/1Ei6tEYGPF6Qit4MQ40k2SsxHJfJPOAwA" target="_blank"
+						rel="noopener noreferrer" class="align-middle"><i
+							class="material-icons align-middle">menu_book</i> Material Prático</a>
 				</h3>
 			</div>
 			<div class="modal-footer">
@@ -148,14 +150,17 @@
 					heterogêneos e impulsione sua carreira com conhecimentos de ponta!</p>
 				<br>
 				<h3>Material do Curso</h3>
-				<h3><a href="https://www.youtube.com/playlist?list=PL7Od71iXIaNmvz2Wp2_cEP71JnmzypQ4V"
-						class="align-middle"><i class="material-icons align-middle">video_library</i> Aulas em vídeo</a>
+				<h3><a href="https://www.youtube.com/playlist?list=PL7Od71iXIaNmvz2Wp2_cEP71JnmzypQ4V" target="_blank"
+						rel="noopener noreferrer" class="align-middle"><i
+							class="material-icons align-middle">video_library</i> Aulas em vídeo</a>
 				</h3><br>
-				<h3><a href="https://drive.google.com/drive/folders/1rwQzZ7hWBHo5zJwfdCe7LeI0eHbc4oy0"
-						class="align-middle"><i class="material-icons align-middle">menu_book</i> Material Teórico</a>
+				<h3><a href="https://drive.google.com/drive/folders/1rwQzZ7hWBHo5zJwfdCe7LeI0eHbc4oy0" target="_blank"
+						rel="noopener noreferrer" class="align-middle"><i
+							class="material-icons align-middle">menu_book</i> Material Teórico</a>
 				</h3><br>
-				<h3><a href="https://github.com/TIC-13/luxai_cuda_samples" class="align-middle"><i
-							class="material-icons align-middle">code</i> Github com exercícios e exemplos</a></h3>
+				<h3><a href="https://github.com/TIC-13/luxai_cuda_samples" target="_blank" rel="noopener noreferrer"
+						class="align-middle"><i class="material-icons align-middle">code</i> Github com exercícios e
+						exemplos</a></h3>
 			</div>
 			<div class="modal-footer">
 				<button type="button" class="btn btn-secondary" data-dismiss="modal">Fechar</button>

--- a/benchmarks.html
+++ b/benchmarks.html
@@ -32,7 +32,6 @@
 	<link href="https://fonts.googleapis.com/css?family=Poppins:400,700|Righteous&display=swap" rel="stylesheet">
 	<!-- owl stylesheets -->
 	<link rel="stylesheet" href="css/owl.carousel.min.css">
-	<link rel="stylesheet" href="css/owl.theme.default.min.css">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css"
 		media="screen">
 </head>
@@ -112,7 +111,6 @@
 	<script src="js/jquery.mCustomScrollbar.concat.min.js"></script>
 	<script src="js/custom.js"></script>
 	<!-- javascript -->
-	<script src="js/owl.carousel.js"></script>
 	<script src="https:cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 </body>
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -7,11 +7,44 @@
     text-align: justify;
 }
 
-.depoimento_carousel{
+.depoimento_carousel {
     padding-top: 20;
 }
 
-.material_image{
-    box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+.material_image {
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
     /* Got it from https://htmlcssfreebies.com/material-design-box-shadows/ */
+}
+
+@media (max-width: 767px) {
+    .dropdown-menu {
+        background-color: rgba(255, 255, 255, 0.1);
+    }
+}
+
+@media (min-width: 768px) {
+    .dropdown-menu {
+        background-color: rgba(0, 0, 0, 0.75);
+    }
+}
+
+.navbar-light .navbar-nav .active>.nav-link,
+.navbar-light .navbar-nav .nav-link.active,
+.navbar-light .navbar-nav .nav-link.show,
+.navbar-light .navbar-nav .show>.nav-link {
+
+    background: transparent !important;
+    color: #fff !important;
+}
+
+.navbar-light .navbar-nav .nav-link:focus,
+.navbar-light .navbar-nav .nav-link:hover {
+
+    background: #2b2278 !important;
+    color: #fff !important;
+}
+
+.navbar-light .navbar-nav .nav-link:focus {
+
+    background: transparent !important;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -234,7 +234,6 @@ button {
     background-image: url(../images/banner-bg.png);
     height: auto;
     background-size: 100%;
-    padding: 0px 0px 20px 0px;
 }
 
 .bg-light {
@@ -245,14 +244,12 @@ button {
     width: 100%;
     float: left;
     text-align: center;
-    padding: 20px 0px 50px 0px;
 }
 
 .logo_mobile {
     width: 100%;
     float: left;
     text-align: center;
-    padding-bottom: 20px;
 }
 
 .mobile_menu {
@@ -338,7 +335,6 @@ button {
 .header_main {
     width: 100%;
     background-size: 100%;
-    padding: 10px 0px 0px 0px;
 }
 
 

--- a/css/style.css
+++ b/css/style.css
@@ -244,6 +244,8 @@ button {
     width: 100%;
     float: left;
     text-align: center;
+    padding-right: 50px;
+    max-width: 178px;
 }
 
 .logo_mobile {
@@ -287,7 +289,7 @@ button {
 .menu_main {
     -ms-flex-direction: column;
     flex-direction: column;
-    padding-left: 0;
+    padding: 20px 0;
     margin-bottom: 0;
     list-style: none;
     width: 100%;

--- a/css/style.css
+++ b/css/style.css
@@ -337,7 +337,6 @@ button {
 
 .header_main {
     width: 100%;
-    background-image: url(../images/header-bg.png);
     background-size: 100%;
     padding: 10px 0px 0px 0px;
 }

--- a/cursos.html
+++ b/cursos.html
@@ -32,7 +32,6 @@
 	<link href="https://fonts.googleapis.com/css?family=Poppins:400,700|Righteous&display=swap" rel="stylesheet">
 	<!-- owl stylesheets -->
 	<link rel="stylesheet" href="css/owl.carousel.min.css">
-	<link rel="stylesheet" href="css/owl.theme.default.min.css">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css"
 		media="screen">
 	<!-- Google Icons -->
@@ -197,7 +196,6 @@
 	<script src="js/jquery.mCustomScrollbar.concat.min.js"></script>
 	<script src="js/custom.js"></script>
 	<!-- javascript -->
-	<script src="js/owl.carousel.js"></script>
 	<script src="https:cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -32,7 +32,6 @@
    <link href="https://fonts.googleapis.com/css?family=Poppins:400,700|Righteous&display=swap" rel="stylesheet">
    <!-- owl stylesheets -->
    <link rel="stylesheet" href="css/owl.carousel.min.css">
-   <link rel="stylesheet" href="css/owl.theme.default.min.css">
    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css"
       media="screen">
 </head>
@@ -151,7 +150,6 @@
    <script src="js/jquery.mCustomScrollbar.concat.min.js"></script>
    <script src="js/custom.js"></script>
    <!-- javascript -->
-   <script src="js/owl.carousel.js"></script>
    <script src="https:cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 </body>
 

--- a/publicacoes.html
+++ b/publicacoes.html
@@ -32,7 +32,6 @@
 	<link href="https://fonts.googleapis.com/css?family=Poppins:400,700|Righteous&display=swap" rel="stylesheet">
 	<!-- owl stylesheets -->
 	<link rel="stylesheet" href="css/owl.carousel.min.css">
-	<link rel="stylesheet" href="css/owl.theme.default.min.css">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css"
 		media="screen">
 	<!-- Google Icons -->
@@ -113,7 +112,6 @@
 	<script src="js/jquery.mCustomScrollbar.concat.min.js"></script>
 	<script src="js/custom.js"></script>
 	<!-- javascript -->
-	<script src="js/owl.carousel.js"></script>
 	<script src="https:cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 </body>
 

--- a/run_locally/_setup_local_installation.sh
+++ b/run_locally/_setup_local_installation.sh
@@ -1,12 +1,12 @@
 # Install latest Ruby version from official website
-https://www.ruby-lang.org/en/documentation/installation/
+# https://www.ruby-lang.org/en/documentation/installation/
 
 # Install Jekyll and Buncle
 gem install jekyll bundler
 # Update Rubygems, if requested
 
 # Copy _config.yml to your repository root folder. Make sure it is included in the .ignore, as it should not be pushed to GitHub (it may mess up local GitHub Pages Actions)
-cd REPOSITORY_FOLDER
+# cd REPOSITORY_FOLDER
 cp ./run_locally/default_config.yml ./_config.yml
 
 # On your repository folder, install github pages gem and its dependencies

--- a/run_locally/_setup_local_installation.sh
+++ b/run_locally/_setup_local_installation.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Install latest Ruby version from official website
 # https://www.ruby-lang.org/en/documentation/installation/
 

--- a/sobre.html
+++ b/sobre.html
@@ -32,7 +32,6 @@
    <link href="https://fonts.googleapis.com/css?family=Poppins:400,700|Righteous&display=swap" rel="stylesheet">
    <!-- owl stylesheets -->
    <link rel="stylesheet" href="css/owl.carousel.min.css">
-   <link rel="stylesheet" href="css/owl.theme.default.min.css">
    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css"
       media="screen">
 </head>
@@ -69,7 +68,6 @@
    <script src="js/jquery.mCustomScrollbar.concat.min.js"></script>
    <script src="js/custom.js"></script>
    <!-- javascript -->
-   <script src="js/owl.carousel.js"></script>
    <script src="https:cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js"></script>
 </body>
 


### PR DESCRIPTION
### Update launch tutorial
* Renamed `_setup_local_installation` to `_setup_local_installation.sh`
* Changed structure to run as a shellscript file (just need to run `chmod +x _setup_local_installation.sh` locally) :smile:

### Removing outdated references
* No one knows why **owl.theme.default.min.css** and **owl.carousel.js** are not present in the repo :upside_down_face: 
  * Apparently they were never used and the carousel js and css code is currently not located (after a few hours of thorough search)
* **header-bg.png** was removed in an earlier commit to make the banner background transparent, but the reference in CSS was not removed
  * Well, that's fixed now! :broom: :wastebasket: 

### Fixing links for courses and e-mail
* Now the weblinks to all the course modals and the link to send an email (present in the footer) now redirect the user to another page. This way we can keep the users in our page while they open external links :sunglasses:

### Update navigation
* Well, this took some time. In some desktop screens, the navigation bar appeared cutoff and some links were unclickable :confused: 
* To fix this, 3 links were integrated into the dropdown **Soluções**: **Cursos**, **LLMs** and **Benchmarks** :nerd_face: 
* Navigation style was also adapted to have a light background on mobile (as the banner background is colored and the droopdown shows above it) and a dark background on desktop (as the dropdown shows above the white background from the page) :+1: 
* The banner links hover style was also changed to be uniform across all screen sizes :wink: