### PR TITLE
Adding "space" (&nbsp) before new dropdown menu items

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,9 +22,9 @@
                      Soluções
                   </a>
                   <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                     <a class="nav-link dropdown-item" href="cursos.html">&nbsp;Cursos</a>
-                     <a class="nav-link dropdown-item" href="benchmarks.html">&nbsp;Benchmarks</a>
-                     <a class="nav-link dropdown-item" href="LLMs.html">&nbsp;LLMs</a>
+                     <a class="nav-link dropdown-item" href="cursos.html">Cursos</a>
+                     <a class="nav-link dropdown-item" href="benchmarks.html">Benchmarks</a>
+                     <a class="nav-link dropdown-item" href="LLMs.html">LLMs</a>
                      <!--a class="nav-link dropdown-item" href="apps.html">Apps</a-->
                   </div>
                </li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,9 +22,9 @@
                      Soluções
                   </a>
                   <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                     <a class="nav-link dropdown-item" href="cursos.html">Cursos</a>
-                     <a class="nav-link dropdown-item" href="benchmarks.html">Benchmarks</a>
-                     <a class="nav-link dropdown-item" href="LLMs.html">LLMs</a>
+                     <a class="nav-link dropdown-item" href="cursos.html">&nbsp;Cursos</a>
+                     <a class="nav-link dropdown-item" href="benchmarks.html">&nbsp;Benchmarks</a>
+                     <a class="nav-link dropdown-item" href="LLMs.html">&nbsp;LLMs</a>
                      <!--a class="nav-link dropdown-item" href="apps.html">Apps</a-->
                   </div>
                </li>

--- a/css/custom.css
+++ b/css/custom.css
@@ -28,6 +28,10 @@
     }
 }
 
+.mobile_menu .dropdown-item {
+    padding-left: 20;
+}
+
 .navbar-light .navbar-nav .active>.nav-link,
 .navbar-light .navbar-nav .nav-link.active,
 .navbar-light .navbar-nav .nav-link.show,


### PR DESCRIPTION
**On mobile, the dropdown items were not aligned with dropdown overlay (they were merged with overlay edge). A space was added before each dropdown item, as presented below:**

Before / After modifications:
![image](https://github.com/user-attachments/assets/5c182d6d-171b-44a5-845d-66292cc91654)
![image](https://github.com/user-attachments/assets/c698b529-94c3-4344-8c0c-720b4f13a1f8)

---

Refference to `&nbsp`: [w3schools.com](https://www.w3schools.com/html/html_entities.asp)

```html
<div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
   <a class="nav-link dropdown-item" href="cursos.html">&nbsp;Cursos</a>
   <a class="nav-link dropdown-item" href="benchmarks.html">&nbsp;Benchmarks</a>
   <a class="nav-link dropdown-item" href="LLMs.html">&nbsp;LLMs</a>
</div>
```